### PR TITLE
Fix crash caused by missing `summary` in the SPI API response

### DIFF
--- a/Sources/PackageListTool/Models/API+APIPackage.swift
+++ b/Sources/PackageListTool/Models/API+APIPackage.swift
@@ -22,7 +22,7 @@ extension API {
         var license: License
         var stars: Int
         var swiftVersionCompatibility: [SwiftVersion]
-        var summary: String
+        var summary: String?
         var title: String
         var url: String
     }

--- a/Sources/PackageListTool/Models/API+YMLPackage.swift
+++ b/Sources/PackageListTool/Models/API+YMLPackage.swift
@@ -30,7 +30,7 @@ extension API {
 
         init(from package: APIPackage) {
             self.name = package.title
-            self.description = package.summary
+            self.description = package.summary ?? ""
             self.swiftCompatibility = package.swiftVersionCompatibility.sorted().first.map { "\($0.major).\($0.minor)+" } ?? "unknown"
             self.platformCompatibility = package.platformCompatibility.map(\.rawValue)
             self.activity = package.activityClause


### PR DESCRIPTION
When querying a package without a summary, the tool crashed with:

```
Error: keyNotFound(CodingKeys(stringValue: "summary", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key CodingKeys(stringValue: \"summary\", intValue: nil) (\"summary\").", underlyingError: nil))
```