### PR TITLE
Ensure package descriptions are always trimmed

### DIFF
--- a/Sources/PackageListTool/Commands/GeneratePackageYML.swift
+++ b/Sources/PackageListTool/Commands/GeneratePackageYML.swift
@@ -51,7 +51,7 @@ public struct GeneratePackageYML: AsyncParsableCommand {
             guard let summary = getSummary(for: packageId, descriptionsDirectory: descriptionsDirectory) else {
                 throw Error.summaryNotFound(for: packageId)
             }
-            apiPackage.summary = summary
+            apiPackage.summary = summary.trimmingCharacters(in: .whitespacesAndNewlines)
             let pkg = API.YMLPackage(from: apiPackage)
             packages.append(pkg)
         }


### PR DESCRIPTION
Merge after #18 

When tweaking descriptions in a text editor, the editor can add newlines.