### PR TITLE
YAML formatting options

### DIFF
--- a/Sources/PackageListTool/Commands/GeneratePackageYML.swift
+++ b/Sources/PackageListTool/Commands/GeneratePackageYML.swift
@@ -115,9 +115,23 @@ extension GeneratePackagesYML {
         // Prettier isn't Linux compatible, because it uses JavaScriptCore
         return yml
         #else
-        let fmt = PrettierFormatter(plugins: [YAMLPlugin()], parser: YAMLParser())
-        fmt.prepare()
-        switch fmt.format(yml) {
+        let formatter = PrettierFormatter(plugins: [YAMLPlugin()], parser: YAMLParser())
+        formatter.printWidth = 120
+        formatter.tabWidth = 2
+        formatter.useTabs = false
+        formatter.semicolons = false
+        formatter.singleQuote = false
+        formatter.quoteProperties = .asNeeded
+        formatter.jsxSingleQuote = false
+        formatter.trailingCommas = .es5
+        formatter.bracketSpacing = true
+        formatter.bracketSameLine = true
+        formatter.arrowFunctionParentheses = .always
+        formatter.proseWrap = .preserve
+        formatter.htmlWhitespaceSensitivity = .css
+        formatter.endOfLine = .lf
+        formatter.prepare()
+        switch formatter.format(yml) {
             case let .success(output):
                 return output
             case let .failure(error):

--- a/Sources/PackageListTool/Commands/GeneratePackageYML.swift
+++ b/Sources/PackageListTool/Commands/GeneratePackageYML.swift
@@ -90,7 +90,7 @@ public struct GeneratePackagesYML: AsyncParsableCommand {
         }
         let content = try YAMLEncoder().encode(SwiftOrgPackageLists(categories: outputCategories))
         let reformatted = Self.reformatYMLToSwiftOrgStyle(content)
-        try Data(content.utf8).write(to: URL(filePath: reformatted))
+        try Data(reformatted.utf8).write(to: URL(filePath: output))
     }
 
     enum Error: Swift.Error {


### PR DESCRIPTION
There's no easy way to attach a `.prettierrc`, but every option inside it has been mapped. 🎉 Thanks for doing such a comprehensive job, @simonbs!

We don't need all these options for formatting a YML file, but it's as easy to include them all 👍