### PR TITLE
Add source search parameter

### DIFF
--- a/Sources/PackageListTool/Models/GitHubAPI.swift
+++ b/Sources/PackageListTool/Models/GitHubAPI.swift
@@ -33,7 +33,7 @@ enum GitHubAPI {
         request.addValue("application/vnd.github.raw+json", forHTTPHeaderField: "Accept")
 
         let (data, response) = try await URLSession.shared.data(for: request)
-        assert((response as? HTTPURLResponse)?.statusCode == 200)
+        assert((response as? HTTPURLResponse)?.statusCode == 200, "expected 200, received \(String(describing: (response as? HTTPURLResponse)?.statusCode))")
         let readme = String(decoding: data, as: UTF8.self)
 
         return readme

--- a/Sources/PackageListTool/Models/PackageId.swift
+++ b/Sources/PackageListTool/Models/PackageId.swift
@@ -19,6 +19,11 @@ struct PackageId: ExpressibleByArgument, Codable, CustomStringConvertible {
     var owner: String
     var repository: String
 
+    init(owner: String, repository: String) {
+        self.owner = owner
+        self.repository = repository
+    }
+
     init?(argument: String) {
         let parts = argument.split(separator: "/").map(String.init)
         guard parts.count == 2 else { return nil }

--- a/Sources/PackageListTool/Models/SourcePackageLists.swift
+++ b/Sources/PackageListTool/Models/SourcePackageLists.swift
@@ -75,14 +75,16 @@ struct SourcePackageLists: Codable {
 
 extension SourcePackageLists.Category {
     static var searchCache = [String: [SourcePackageLists.Package]]()
-    var packages: [SourcePackageLists.Package] {
+    func packageIds(api: SwiftPackageIndexAPI) async throws -> [SourcePackageLists.Package] {
         switch source {
             case let .searchQuery(query):
                 if let packages = Self.searchCache[query] {
                     return packages
                 }
-                // FIXME: make search query
-                return []
+                let ids = try await api.search(query: query)
+                let packages = ids.map { SourcePackageLists.Package("\($0.owner)/\($0.repository)") }
+                Self.searchCache[query] = packages
+                return packages
             case let .packages(packages):
                 return packages
         }

--- a/Sources/PackageListTool/Models/SourcePackageLists.swift
+++ b/Sources/PackageListTool/Models/SourcePackageLists.swift
@@ -59,19 +59,6 @@ struct SourcePackageLists: Codable {
             case identifier
             case note
         }
-        
-        init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.identifier = try container.decode(String.self, forKey: CodingKeys.identifier)
-            self.note = try container.decodeIfPresent(String.self, forKey: CodingKeys.note)
-            
-        }
-        
-        func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encode(self.identifier, forKey: CodingKeys.identifier)
-            try container.encodeIfPresent(self.note, forKey: CodingKeys.note)
-        }
     }
 }
 

--- a/Sources/PackageListTool/Models/SourcePackageLists.swift
+++ b/Sources/PackageListTool/Models/SourcePackageLists.swift
@@ -61,18 +61,16 @@ struct SourcePackageLists: Codable {
         }
         
         init(from decoder: Decoder) throws {
-            let container: KeyedDecodingContainer<SourcePackageLists.Package.CodingKeys> = try decoder.container(keyedBy: SourcePackageLists.Package.CodingKeys.self)
-            
-            self.identifier = try container.decode(String.self, forKey: SourcePackageLists.Package.CodingKeys.identifier)
-            self.note = try container.decodeIfPresent(String.self, forKey: SourcePackageLists.Package.CodingKeys.note)
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.identifier = try container.decode(String.self, forKey: CodingKeys.identifier)
+            self.note = try container.decodeIfPresent(String.self, forKey: CodingKeys.note)
             
         }
         
         func encode(to encoder: Encoder) throws {
-            var container: KeyedEncodingContainer<SourcePackageLists.Package.CodingKeys> = encoder.container(keyedBy: SourcePackageLists.Package.CodingKeys.self)
-            
-            try container.encode(self.identifier, forKey: SourcePackageLists.Package.CodingKeys.identifier)
-            try container.encodeIfPresent(self.note, forKey: SourcePackageLists.Package.CodingKeys.note)
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(self.identifier, forKey: CodingKeys.identifier)
+            try container.encodeIfPresent(self.note, forKey: CodingKeys.note)
         }
     }
 }

--- a/Sources/PackageListTool/Models/SourcePackageLists.swift
+++ b/Sources/PackageListTool/Models/SourcePackageLists.swift
@@ -71,7 +71,7 @@ extension SourcePackageLists.Category {
                 if let packages = Self.searchCache[search.query] {
                     return packages
                 }
-                let ids = try await api.search(query: search.query).prefix(search.limit)
+                let ids = try await api.search(query: search.query, limit: search.limit)
                 let packages = ids.map { SourcePackageLists.Package("\($0.owner)/\($0.repository)") }
                 Self.searchCache[search.query] = packages
                 return packages

--- a/Sources/PackageListTool/Models/SourcePackageLists.swift
+++ b/Sources/PackageListTool/Models/SourcePackageLists.swift
@@ -26,7 +26,7 @@ struct SourcePackageLists: Codable {
         var more: MoreLink? = nil
         var source: Source
 
-        enum Source {
+        enum Source: Equatable {
             case searchQuery(String)
             case packages([Package])
         }
@@ -37,7 +37,7 @@ struct SourcePackageLists: Codable {
         }
     }
 
-    struct Package: Codable {
+    struct Package: Codable, Equatable {
         var identifier: String
         var note: String? = nil
 
@@ -45,6 +45,11 @@ struct SourcePackageLists: Codable {
             PackageId(argument: identifier)
         }
         
+        init(_ identifier: String, note: String? = nil) {
+            self.identifier = identifier
+            self.note = note
+        }
+
         enum CodingKeys: CodingKey {
             case identifier
             case note

--- a/Sources/PackageListTool/Models/SwiftPackageIndexAPI.swift
+++ b/Sources/PackageListTool/Models/SwiftPackageIndexAPI.swift
@@ -38,10 +38,13 @@ struct SwiftPackageIndexAPI {
         return try Self.decoder.decode(Package.self, from: data)
     }
 
-    func search(query: String) async throws -> [PackageId] {
-        let queryItem = URLQueryItem(name: "query", value: query)
+    func search(query: String, limit: Int) async throws -> [PackageId] {
         var urlComponents = URLComponents(string: "\(baseURL)/api/search")
-        urlComponents?.queryItems = [queryItem]
+        urlComponents?.queryItems = [
+            URLQueryItem(name: "query", value: query),
+            URLQueryItem(name: "page", value: "1"),
+            URLQueryItem(name: "pageSize", value: "\(limit)"),
+        ]
         guard let url = urlComponents?.url else {
             throw Error(message: "Failed to construct search query URL")
         }

--- a/Tests/PackageListToolTests/API+APIPackageTests.swift
+++ b/Tests/PackageListToolTests/API+APIPackageTests.swift
@@ -86,11 +86,13 @@ class API_APIPackageTests: XCTestCase {
         }
         do {
             let yml = """
-                searchQuery: some query
-
+                search:
+                  query: some query
+                  limit: 6
+                
                 """
             let res = try YAMLDecoder().decode(SourcePackageLists.Category.Source.self, from: yml)
-            XCTAssertEqual(res, .searchQuery("some query"))
+            XCTAssertEqual(res, .search(.init(query: "some query", limit: 6)))
             XCTAssertEqual(try YAMLEncoder().encode(res), yml)
         }
     }

--- a/Tests/PackageListToolTests/API+APIPackageTests.swift
+++ b/Tests/PackageListToolTests/API+APIPackageTests.swift
@@ -16,6 +16,8 @@ import XCTest
 
 @testable import PackageListTool
 
+import Yams
+
 class API_APIPackageTests: XCTestCase {
 
     func test_groupedPlatformCompatibility() throws {
@@ -70,4 +72,27 @@ class API_APIPackageTests: XCTestCase {
             """)
         #endif
     }
+
+    func test_Source_Codable() throws {
+        do {
+            let yml = """
+                packages:
+                - identifier: apple/swift-nio
+
+                """
+            let res = try YAMLDecoder().decode(SourcePackageLists.Category.Source.self, from: yml)
+            XCTAssertEqual(res, .packages([SourcePackageLists.Package("apple/swift-nio")]))
+            XCTAssertEqual(try YAMLEncoder().encode(res), yml)
+        }
+        do {
+            let yml = """
+                searchQuery: some query
+
+                """
+            let res = try YAMLDecoder().decode(SourcePackageLists.Category.Source.self, from: yml)
+            XCTAssertEqual(res, .searchQuery("some query"))
+            XCTAssertEqual(try YAMLEncoder().encode(res), yml)
+        }
+    }
+
 }

--- a/source_template.yml
+++ b/source_template.yml
@@ -5,15 +5,22 @@ categories:
     more:
       title: More packages
       url: https://example.com/more/packages
-    packages:
-      - identifier: pointfreeco/swift-composable-architecture
-      - identifier: groue/Semaphore
-        note: "Notes are optional and per-package, not per-category."
-      - identifier: QuickBirdEng/DataKit
-        note: "Notes can also include [Markdown](https://example.com)."
+    source:
+        packages:
+          - identifier: pointfreeco/swift-composable-architecture
+          - identifier: groue/Semaphore
+            note: "Notes are optional and per-package, not per-category."
+          - identifier: QuickBirdEng/DataKit
+            note: "Notes can also include [Markdown](https://example.com)."
   - name: Networking
     anchor: networking
     description: "Descriptions are required, but 'more' links are optional."
-    packages:
-      - identifier: apple/swift-nio
-      - identifier: Alamofire/Alamofire
+    source:
+        packages:
+          - identifier: apple/swift-nio
+          - identifier: Alamofire/Alamofire
+  - name: Testing
+    anchor: testing
+    description: "This list is driven by a live keyword search on SPI."
+    source:
+        searchQuery: 'testing'

--- a/source_template.yml
+++ b/source_template.yml
@@ -23,4 +23,6 @@ categories:
     anchor: testing
     description: "This list is driven by a live keyword search on SPI."
     source:
-        searchQuery: 'testing'
+        search:
+            query: 'testing'
+            limit: 6


### PR DESCRIPTION
Merge after #29 

This replaces the `packages:` key with a `source:` key that supports both static package lists as well as dynamic search:

```yml
  - name: Networking
    anchor: networking
    description: "Descriptions are required, but 'more' links are optional."
    source:
        packages:
          - identifier: apple/swift-nio
          - identifier: Alamofire/Alamofire
  - name: Testing
    anchor: testing
    description: "This list is driven by a live keyword search on SPI."
    source:
        search:
            query: 'testing'
            limit: 6
```