### PR TITLE
Make the SwiftPackageIndexAPI public

### DIFF
--- a/Sources/PackageListTool/Models/PackageId.swift
+++ b/Sources/PackageListTool/Models/PackageId.swift
@@ -15,7 +15,7 @@
 import Foundation
 import ArgumentParser
 
-struct PackageId: ExpressibleByArgument, Codable, CustomStringConvertible {
+public struct PackageId: ExpressibleByArgument, Codable, CustomStringConvertible {
     var owner: String
     var repository: String
 
@@ -24,14 +24,14 @@ struct PackageId: ExpressibleByArgument, Codable, CustomStringConvertible {
         self.repository = repository
     }
 
-    init?(argument: String) {
+    public init?(argument: String) {
         let parts = argument.split(separator: "/").map(String.init)
         guard parts.count == 2 else { return nil }
         self.owner = parts[0]
         self.repository = parts[1]
     }
 
-    var description: String {
+    public var description: String {
         "\(owner)/\(repository)"
     }
 

--- a/Sources/PackageListTool/Models/SwiftPackageIndexAPI+ImportedModels.swift
+++ b/Sources/PackageListTool/Models/SwiftPackageIndexAPI+ImportedModels.swift
@@ -17,7 +17,7 @@ import Foundation
 
 // Type pulled 1:1 from SwiftPackageIndex-Server
 extension SwiftPackageIndexAPI {
-    struct Activity: Codable, Equatable {
+    public struct Activity: Codable, Equatable {
         var openIssuesCount: Int
         var openIssuesURL: String?
         var openPullRequestsCount: Int
@@ -26,16 +26,16 @@ extension SwiftPackageIndexAPI {
         var lastPullRequestClosedAt: Date?
     }
 
-    struct Author: Codable, Equatable {
+    public struct Author: Codable, Equatable {
         var name: String
     }
 
-    enum AuthorMetadata : Codable, Equatable {
+    public enum AuthorMetadata : Codable, Equatable {
         case fromSPIManifest(String)
         case fromGitRepository(PackageAuthors)
     }
 
-    struct History: Codable, Equatable {
+    public struct History: Codable, Equatable {
         var createdAt: Date
         var commitCount: Int
         var commitCountURL: String
@@ -43,7 +43,7 @@ extension SwiftPackageIndexAPI {
         var releaseCountURL: String
     }
 
-    enum License: String, Codable, Equatable, CaseIterable {
+    public enum License: String, Codable, Equatable, CaseIterable {
         // This is not an exhaustive list, but includes most commonly used license types
         case afl_3_0 = "afl-3.0"
         case apache_2_0 = "apache-2.0"
@@ -176,7 +176,7 @@ extension SwiftPackageIndexAPI {
             }
         }
 
-        enum Kind: String {
+        public enum Kind: String {
             case none
             case other
             case incompatibleWithAppStore = "incompatible"
@@ -193,26 +193,26 @@ extension SwiftPackageIndexAPI {
         }
     }
 
-    struct PackageAuthors: Codable, Equatable {
+    public struct PackageAuthors: Codable, Equatable {
         var authors: [Author]
         var numberOfContributors: Int
     }
 
-    enum PlatformCompatibility: String, Codable, Comparable {
+    public enum PlatformCompatibility: String, Codable, Comparable {
         case iOS
         case linux
         case macOS
         case tvOS
         case visionOS
         case watchOS
-        static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+        public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
     }
 
-    struct SwiftVersion: Codable, Comparable {
+    public struct SwiftVersion: Codable, Comparable {
         var major: Int
         var minor: Int
         var patch: Int
-        static func < (lhs: Self, rhs: Self) -> Bool {
+        public static func < (lhs: Self, rhs: Self) -> Bool {
             if lhs.major != rhs.major { return lhs.major < rhs.major }
             if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
             return lhs.patch < rhs.patch

--- a/Sources/PackageListTool/Models/SwiftPackageIndexAPI+Package.swift
+++ b/Sources/PackageListTool/Models/SwiftPackageIndexAPI+Package.swift
@@ -15,7 +15,7 @@
 import Collections
 
 extension SwiftPackageIndexAPI {
-    struct Package: Codable {
+    public struct Package: Codable {
         var repositoryOwner: String
         var repositoryName: String
         var repositoryOwnerName: String?
@@ -27,7 +27,7 @@ extension SwiftPackageIndexAPI {
         var url: String
 
 
-        enum PlatformCompatibilityGroup: String, CaseIterable, Codable {
+        public enum PlatformCompatibilityGroup: String, CaseIterable, Codable {
             case apple = "Apple"
             case linux = "Linux"
 
@@ -43,13 +43,13 @@ extension SwiftPackageIndexAPI {
 }
 
 extension SwiftPackageIndexAPI.Package {
-    var groupedPlatformCompatibility: [PlatformCompatibilityGroup] {
+    public var groupedPlatformCompatibility: [PlatformCompatibilityGroup] {
         PlatformCompatibilityGroup.allCases.filter { group in
             Set(platformCompatibility ?? []).isDisjoint(with: group.platforms) == false
         }
     }
 
-    var platformCompatibilityTooltip: String {
+    public var platformCompatibilityTooltip: String {
         groupedPlatformCompatibility.map { group in
             let platforms = group.platforms.intersection(Set(platformCompatibility ?? []))
             if group == .apple {

--- a/Sources/PackageListTool/Models/SwiftPackageIndexAPI.swift
+++ b/Sources/PackageListTool/Models/SwiftPackageIndexAPI.swift
@@ -16,7 +16,7 @@
 import Foundation
 
 
-struct SwiftPackageIndexAPI {
+public struct SwiftPackageIndexAPI {
     var baseURL: String
     var apiToken: String
 
@@ -30,7 +30,7 @@ struct SwiftPackageIndexAPI {
         return decoder
     }
 
-    func fetchPackage(owner: String, repository: String) async throws -> Package {
+    public func fetchPackage(owner: String, repository: String) async throws -> Package {
         let url = URL(string: "\(baseURL)/api/packages/\(owner)/\(repository)")!
         var req = URLRequest(url: url)
         req.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
@@ -40,7 +40,7 @@ struct SwiftPackageIndexAPI {
         return try Self.decoder.decode(Package.self, from: data)
     }
 
-    func search(query: String, limit: Int) async throws -> [PackageId] {
+    public func search(query: String, limit: Int) async throws -> [PackageId] {
         var urlComponents = URLComponents(string: "\(baseURL)/api/search")
         urlComponents?.queryItems = [
             URLQueryItem(name: "query", value: query),
@@ -66,7 +66,7 @@ struct SwiftPackageIndexAPI {
         return ids
     }
 
-    struct SearchResponse: Decodable {
+    public struct SearchResponse: Decodable {
         var hasMoreResults: Bool
         var results: [Result]
 


### PR DESCRIPTION
(and related types) - for easier consumption as a dependency


(I will totally understand if you'd prefer this to NOT happen, but figured I'd try and see how much you complained. Seems like it I'd get a lot more progress out of this using it directly rather than copying the relevant files again into my own project ([SPISearch](https://github.com/heckj/SPISearch/)) for the experimental stuff I'm fiddling with)
