### PR TITLE
adds more public access

### DIFF
--- a/Sources/PackageListTool/Models/PackageId.swift
+++ b/Sources/PackageListTool/Models/PackageId.swift
@@ -16,8 +16,8 @@ import Foundation
 import ArgumentParser
 
 public struct PackageId: ExpressibleByArgument, Codable, CustomStringConvertible {
-    var owner: String
-    var repository: String
+    public var owner: String
+    public var repository: String
 
     init(owner: String, repository: String) {
         self.owner = owner

--- a/Sources/PackageListTool/Models/SwiftPackageIndexAPI+Package.swift
+++ b/Sources/PackageListTool/Models/SwiftPackageIndexAPI+Package.swift
@@ -16,16 +16,15 @@ import Collections
 
 extension SwiftPackageIndexAPI {
     public struct Package: Codable {
-        var repositoryOwner: String
-        var repositoryName: String
-        var repositoryOwnerName: String?
-        var platformCompatibility: [PlatformCompatibility]?
-        var license: License
-        var swiftVersionCompatibility: [SwiftVersion]?
-        var summary: String?
-        var title: String
-        var url: String
-
+        public var repositoryOwner: String
+        public var repositoryName: String
+        public var repositoryOwnerName: String?
+        public var platformCompatibility: [PlatformCompatibility]?
+        public var license: License
+        public var swiftVersionCompatibility: [SwiftVersion]?
+        public var summary: String?
+        public var title: String
+        public var url: String
 
         public enum PlatformCompatibilityGroup: String, CaseIterable, Codable {
             case apple = "Apple"

--- a/Sources/PackageListTool/Models/SwiftPackageIndexAPI.swift
+++ b/Sources/PackageListTool/Models/SwiftPackageIndexAPI.swift
@@ -20,6 +20,11 @@ public struct SwiftPackageIndexAPI {
     var baseURL: String
     var apiToken: String
 
+    public init(baseURL: String, apiToken: String) {
+        self.baseURL = baseURL
+        self.apiToken = apiToken
+    }
+    
     struct Error: Swift.Error {
         var message: String
     }
@@ -38,6 +43,10 @@ public struct SwiftPackageIndexAPI {
         assert((response as? HTTPURLResponse)?.statusCode == 200,
                "expected 200, received \(String(describing: (response as? HTTPURLResponse)?.statusCode))")
         return try Self.decoder.decode(Package.self, from: data)
+    }
+
+    public func fetchPackage(packageId: PackageId) async throws -> Package {
+        try await self.fetchPackage(owner: packageId.owner, repository: packageId.repository)
     }
 
     public func search(query: String, limit: Int) async throws -> [PackageId] {


### PR DESCRIPTION
Adds more public access to API referenced types that I missed earlier:
 - properties
 - initializers (in the case of the API endpoint proxy)
 - added a convenience function on fetchPackage that takes a PackageID struct