### PR TITLE
Split months and years into a hierarchy in the showcase history

### DIFF
--- a/Sources/PackageListTool/Commands/GeneratePackageYML.swift
+++ b/Sources/PackageListTool/Commands/GeneratePackageYML.swift
@@ -122,7 +122,7 @@ public struct GeneratePackagesYML: AsyncParsableCommand {
         for year in sourceYears {
             var outputMonths = [SwiftOrgShowcaseHistory.Month]()
             for month in year.months {
-                print("Processing history: \(month.name) \(year.year)...")
+                print("Processing history: \(month.month) \(year.year)...")
 
                 var outputPackages = [SwiftOrgPackageLists.Package]()
                 for sourcePackage in month.packages {
@@ -141,7 +141,7 @@ public struct GeneratePackagesYML: AsyncParsableCommand {
 
                     outputPackages.append(.init(from: apiPackage, note: sourcePackage.note))
                 }
-                outputMonths.append(.init(name: month.name, slug: month.slug, packages: outputPackages))
+                outputMonths.append(.init(month: month.month, slug: month.slug, packages: outputPackages))
             }
             outputYears.append(.init(year: year.year, months: outputMonths))
         }

--- a/Sources/PackageListTool/Commands/GeneratePackageYML.swift
+++ b/Sources/PackageListTool/Commands/GeneratePackageYML.swift
@@ -122,7 +122,7 @@ public struct GeneratePackagesYML: AsyncParsableCommand {
         for year in sourceYears {
             var outputMonths = [SwiftOrgShowcaseHistory.Month]()
             for month in year.months {
-                print("Processing history: \(month.name) \(year.name)...")
+                print("Processing history: \(month.name) \(year.year)...")
 
                 var outputPackages = [SwiftOrgPackageLists.Package]()
                 for sourcePackage in month.packages {
@@ -143,7 +143,7 @@ public struct GeneratePackagesYML: AsyncParsableCommand {
                 }
                 outputMonths.append(.init(name: month.name, slug: month.slug, packages: outputPackages))
             }
-            outputYears.append(.init(name: year.name, months: outputMonths))
+            outputYears.append(.init(year: year.year, months: outputMonths))
         }
         let content = try YAMLEncoder().encode(SwiftOrgShowcaseHistory(years: outputYears))
         let reformatted = Self.reformatYMLToSwiftOrgStyle(content)

--- a/Sources/PackageListTool/Models/SourcePackageLists.swift
+++ b/Sources/PackageListTool/Models/SourcePackageLists.swift
@@ -54,7 +54,7 @@ struct SourcePackageLists: Codable {
         var months: [Month]
 
         struct Month: Codable {
-            var name: String
+            var month: String
             var slug: String
             var packages: [Package]
         }

--- a/Sources/PackageListTool/Models/SourcePackageLists.swift
+++ b/Sources/PackageListTool/Models/SourcePackageLists.swift
@@ -18,7 +18,7 @@ import Foundation
 
 struct SourcePackageLists: Codable {
     var categories: [Category]
-    var showcaseHistory: [Month]
+    var showcaseHistory: [HistoryYear]
 
     enum CodingKeys: String, CodingKey {
         case categories
@@ -49,12 +49,16 @@ struct SourcePackageLists: Codable {
         }
     }
 
-    struct Month: Codable {
-        var name: String
-        var slug: String
-        var packages: [Package]
-    }
+    struct HistoryYear: Codable {
+        var name: Int
+        var months: [Month]
 
+        struct Month: Codable {
+            var name: String
+            var slug: String
+            var packages: [Package]
+        }
+    }
 
     struct Package: Codable, Equatable {
         var identifier: String

--- a/Sources/PackageListTool/Models/SourcePackageLists.swift
+++ b/Sources/PackageListTool/Models/SourcePackageLists.swift
@@ -50,7 +50,7 @@ struct SourcePackageLists: Codable {
     }
 
     struct HistoryYear: Codable {
-        var name: Int
+        var year: Int
         var months: [Month]
 
         struct Month: Codable {

--- a/Sources/PackageListTool/Models/SwiftOrgShowcaseHistory.swift
+++ b/Sources/PackageListTool/Models/SwiftOrgShowcaseHistory.swift
@@ -16,7 +16,12 @@
 import Foundation
 
 struct SwiftOrgShowcaseHistory: Codable {
-    var months: [Month]
+    var years: [Year]
+
+    struct Year: Codable {
+        var name: Int
+        var months: [Month]
+    }
 
     struct Month: Codable {
         var name: String

--- a/Sources/PackageListTool/Models/SwiftOrgShowcaseHistory.swift
+++ b/Sources/PackageListTool/Models/SwiftOrgShowcaseHistory.swift
@@ -19,7 +19,7 @@ struct SwiftOrgShowcaseHistory: Codable {
     var years: [Year]
 
     struct Year: Codable {
-        var name: Int
+        var year: Int
         var months: [Month]
     }
 

--- a/Sources/PackageListTool/Models/SwiftOrgShowcaseHistory.swift
+++ b/Sources/PackageListTool/Models/SwiftOrgShowcaseHistory.swift
@@ -24,7 +24,7 @@ struct SwiftOrgShowcaseHistory: Codable {
     }
 
     struct Month: Codable {
-        var name: String
+        var month: String
         var slug: String
         var packages: [SwiftOrgPackageLists.Package]
     }

--- a/source.yml
+++ b/source.yml
@@ -75,7 +75,7 @@ categories:
 showcase_history:
   - year: 2024
     months:
-      - name: March
+      - month: March
         slug: march
         packages:
           - identifier: AparokshaUI/adwaita-swift
@@ -90,7 +90,7 @@ showcase_history:
             note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/33){:target='_blank'}."
           - identifier: frzi/swiftui-model3dview
             note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
-      - name: February
+      - month: February
         slug: february
         packages:
           - identifier: jrothwell/VersionedCodable
@@ -105,7 +105,7 @@ showcase_history:
             note: "Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}."
           - identifier: StefKors/SwiftSummarize
             note: "Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}."
-      - name: January
+      - month: January
         slug: january
         packages:
           - identifier: soto-project/soto
@@ -122,7 +122,7 @@ showcase_history:
             note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
   - year: 2023
     months:
-      - name: December
+      - month: December
         slug: december
         packages:
           - identifier: pointfreeco/swift-composable-architecture
@@ -137,7 +137,7 @@ showcase_history:
             note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}."
           - identifier: daprice/Variablur
             note: "Linked in [Issue 637 of iOS Dev Weekly](https://iosdevweekly.com/issues/637#txS8ASr){:target='_blank'}."
-      - name: November
+      - month: November
         slug: november
         packages:
           - identifier: rensbreur/SwiftTUI

--- a/source.yml
+++ b/source.yml
@@ -73,7 +73,7 @@ categories:
         query: "keyword:logging"
         limit: 6
 showcase_history:
-  - name: 2024
+  - year: 2024
     months:
       - name: March
         slug: march
@@ -120,7 +120,7 @@ showcase_history:
             note: "Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}."
           - identifier: danwood/SwiftUICoreImage
             note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
-  - name: 2023
+  - year: 2023
     months:
       - name: December
         slug: december

--- a/source.yml
+++ b/source.yml
@@ -73,78 +73,82 @@ categories:
         query: "keyword:logging"
         limit: 6
 showcase_history:
-  - name: March 2024
-    slug: march-2024
-    packages:
-      - identifier: AparokshaUI/adwaita-swift
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/30){:target='_blank'}."
-      - identifier: davedelong/time
-        note: "Nominated via two posts in the Swift forums ([1](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'}, [2](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/35){:target='_blank'})."
-      - identifier: 0xLeif/Fork
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/29){:target='_blank'}."
-      - identifier: kean/Nuke
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/27){:target='_blank'}."
-      - identifier: BarredEwe/Prefire
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/33){:target='_blank'}."
-      - identifier: frzi/swiftui-model3dview
-        note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
-  - name: February 2024
-    slug: february-2024
-    packages:
-      - identifier: jrothwell/VersionedCodable
-        note: "Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}."
-      - identifier: richardtop/CalendarKit
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/6){:target='_blank'}."
-      - identifier: stephencelis/SQLite.swift
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/19){:target='_blank'}."
-      - identifier: gonzalezreal/swift-markdown-ui
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}."
-      - identifier: twostraws/Vortex
-        note: "Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}."
-      - identifier: StefKors/SwiftSummarize
-        note: "Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}."
-  - name: January 2024
-    slug: january-2024
-    packages:
-      - identifier: soto-project/soto
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/13){:target='_blank'}."
-      - identifier: EmergeTools/Pow
-        note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
-      - identifier: mattpolzin/OpenAPIKit
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/12){:target='_blank'}."
-      - identifier: ordo-one/package-benchmark
-        note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/11){:target='_blank'}."
-      - identifier: space-code/typhoon
-        note: "Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}."
-      - identifier: danwood/SwiftUICoreImage
-        note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
-  - name: December 2023
-    slug: december-2023
-    packages:
-      - identifier: pointfreeco/swift-composable-architecture
-        note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/3){:target='_blank'}."
-      - identifier: davedelong/time
-        note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'}."
-      - identifier: PureSwift/BluetoothLinux
-        note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}."
-      - identifier: gohanlon/swift-memberwise-init-macro
-        note: "Discussed in [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}."
-      - identifier: uraimo/SwiftyGPIO
-        note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}."
-      - identifier: daprice/Variablur
-        note: "Linked in [Issue 637 of iOS Dev Weekly](https://iosdevweekly.com/issues/637#txS8ASr){:target='_blank'}."
-  - name: November 2023
-    slug: november-2023
-    packages:
-      - identifier: rensbreur/SwiftTUI
-        note: "Discussed on [Episode 163 of the Empower Apps Podcast](https://brightdigit.com/episodes/163-swiftly-tooling-with-pol-piella-abadia/){:target='_blank'}."
-      - identifier: migueldeicaza/SwiftGodot
-        note: "Discussed on [Season 5 Episode 28 of Compile Swift](https://www.compileswift.com/podcast/s05e28/){:target='_blank'} podcast."
-      - identifier: automerge/automerge-swift
-        note: "Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}."
-      - identifier: li3zhen1/Grape
-        note: "Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}."
-      - identifier: ActuallyTaylor/Firefly
-        note: "Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}."
-      - identifier: daily-co/daily-client-ios
-        note: "Discussed on [Episode 162 of the Empower Apps Podcast](https://brightdigit.com/episodes/162-building-a-video-sdk-with-marc-schwieterman/){:target='_blank'}."
+  - name: 2024
+    months:
+      - name: March
+        slug: march
+        packages:
+          - identifier: AparokshaUI/adwaita-swift
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/30){:target='_blank'}."
+          - identifier: davedelong/time
+            note: "Nominated via two posts in the Swift forums ([1](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'}, [2](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/35){:target='_blank'})."
+          - identifier: 0xLeif/Fork
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/29){:target='_blank'}."
+          - identifier: kean/Nuke
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/27){:target='_blank'}."
+          - identifier: BarredEwe/Prefire
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/33){:target='_blank'}."
+          - identifier: frzi/swiftui-model3dview
+            note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
+      - name: February
+        slug: february
+        packages:
+          - identifier: jrothwell/VersionedCodable
+            note: "Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}."
+          - identifier: richardtop/CalendarKit
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/6){:target='_blank'}."
+          - identifier: stephencelis/SQLite.swift
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/19){:target='_blank'}."
+          - identifier: gonzalezreal/swift-markdown-ui
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/24){:target='_blank'}."
+          - identifier: twostraws/Vortex
+            note: "Discussed on [Episode 40 of Swift Package Indexing](https://share.transistor.fm/s/a452cfcd){:target='_blank'}."
+          - identifier: StefKors/SwiftSummarize
+            note: "Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}."
+      - name: January
+        slug: january
+        packages:
+          - identifier: soto-project/soto
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/13){:target='_blank'}."
+          - identifier: EmergeTools/Pow
+            note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
+          - identifier: mattpolzin/OpenAPIKit
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/12){:target='_blank'}."
+          - identifier: ordo-one/package-benchmark
+            note: "Nominated via [this forum post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/11){:target='_blank'}."
+          - identifier: space-code/typhoon
+            note: "Discussed on [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}."
+          - identifier: danwood/SwiftUICoreImage
+            note: "Discussed on [Episode 38 of Swift Package Indexing](https://share.transistor.fm/s/f744b457){:target='_blank'}."
+  - name: 2023
+    months:
+      - name: December
+        slug: december
+        packages:
+          - identifier: pointfreeco/swift-composable-architecture
+            note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/3){:target='_blank'}."
+          - identifier: davedelong/time
+            note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/7){:target='_blank'}."
+          - identifier: PureSwift/BluetoothLinux
+            note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}."
+          - identifier: gohanlon/swift-memberwise-init-macro
+            note: "Discussed in [Episode 37 of Swift Package Indexing](https://share.transistor.fm/s/de52cb62){:target='_blank'}."
+          - identifier: uraimo/SwiftyGPIO
+            note: "Linked from [this Swift forums post](https://forums.swift.org/t/nominations-for-the-packages-community-showcase-on-swift-org/68168/4){:target='_blank'}."
+          - identifier: daprice/Variablur
+            note: "Linked in [Issue 637 of iOS Dev Weekly](https://iosdevweekly.com/issues/637#txS8ASr){:target='_blank'}."
+      - name: November
+        slug: november
+        packages:
+          - identifier: rensbreur/SwiftTUI
+            note: "Discussed on [Episode 163 of the Empower Apps Podcast](https://brightdigit.com/episodes/163-swiftly-tooling-with-pol-piella-abadia/){:target='_blank'}."
+          - identifier: migueldeicaza/SwiftGodot
+            note: "Discussed on [Season 5 Episode 28 of Compile Swift](https://www.compileswift.com/podcast/s05e28/){:target='_blank'} podcast."
+          - identifier: automerge/automerge-swift
+            note: "Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}."
+          - identifier: li3zhen1/Grape
+            note: "Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}."
+          - identifier: ActuallyTaylor/Firefly
+            note: "Discussed on [Episode 36 of Swift Package Indexing](https://swiftpackageindexing.transistor.fm/episodes/36-even-though-the-bug-is-fixed-its-not-over){:target='_blank'}."
+          - identifier: daily-co/daily-client-ios
+            note: "Discussed on [Episode 162 of the Empower Apps Podcast](https://brightdigit.com/episodes/162-building-a-video-sdk-with-marc-schwieterman/){:target='_blank'}."


### PR DESCRIPTION
Necessary change to align with the changes from @federicobucchi in https://github.com/apple/swift-org-website/pull/614.

Do not merge until https://github.com/apple/swift-org-website/pull/614 is merged in case it needs more changes.