### PR TITLE
Compatibility update for new API responses

### DIFF
--- a/Sources/PackageListTool/Models/SwiftPackageIndexAPI+ImportedModels.swift
+++ b/Sources/PackageListTool/Models/SwiftPackageIndexAPI+ImportedModels.swift
@@ -205,6 +205,8 @@ extension SwiftPackageIndexAPI {
         case tvOS
         case visionOS
         case watchOS
+        case wasm
+        case android
         public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
     }
 


### PR DESCRIPTION
I'm going to ask the SWWG about whether we want these shown on the page but for now, this enables the tool to continue working.